### PR TITLE
Added rtsx_usb_sdmmc for ZFS eMMC boot

### DIFF
--- a/hosts/exampleHost/default.nix
+++ b/hosts/exampleHost/default.nix
@@ -22,6 +22,8 @@
         "nvme"
         # for external usb drive
         "uas"
+        # for mmc drive
+        "rtsx_usb_sdmmc"
       ];
       removableEfi = true;
       kernelParams = [ ];


### PR DESCRIPTION
NixOS ZFS boot console would print
`importing root ZFS pool "rpool"...`
`importing boot ZFS pool "bpool"...`
if drivers for the root eMMC device was not found.

Missing storage drivers were found by running `nixos-generate-config`
```
nixos-generate-config --show-hardware-config 2>/dev/null | grep boot.initrd.availableKernelModules | awk -F "[" '{ print $2 }' | awk -F "]" '{ print $1 }'
```
` "ahci" "xhci_pci" "usbhid" "usb_storage" "sd_mod" "sdhci_pci" "rtsx_usb_sdmmc" `